### PR TITLE
adding animationStart output

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ import { MatCarousel, MatCarouselComponent } from '@ngbmodule/material-carousel'
 | `svgIconOverrides`    | `SvgIconOverrides` | Override default carousel icons with registered SVG icons.                 |                   |
 | `pauseOnHover`        | `boolean`          | Override default pause on hover.                                           | `true`            |
 
+
+| Output                |  Type              | Description                                                                |
+| --------------------- | ------------------ | -------------------------------------------------------------------------- |
+| `animationStart`      | `number`           | It emits the currentIndex when animation starts                            |
+| `change`              | `number`           | It emtis the currentIndex when animation ends                              |
+
+
 #### Size Considerations and Recommendations
 By default, `maintainAspectRatio` is true, which means height is controlled through `proportion`.
 

--- a/projects/carousel/src/lib/carousel.component.spec.ts
+++ b/projects/carousel/src/lib/carousel.component.spec.ts
@@ -87,9 +87,10 @@ describe('MatCarouselComponent', () => {
     expect(component.currentIndex).toBe(0);
   });
 
-  describe('@Output(change)', () => {
+  describe('@Output(change) and @Output(animationStart)', () => {
     beforeEach(() => {
       spyOn(component.change, 'emit');
+      spyOn(component.animationStart,'emit')
       component.loop = true;
     });
 
@@ -98,6 +99,7 @@ describe('MatCarouselComponent', () => {
       component.slideTo(idx);
       tick();
 
+      expect(component.animationStart.emit).toHaveBeenCalledWith(idx);
       expect(component.change.emit).toHaveBeenCalledWith(idx);
     }));
 
@@ -105,6 +107,7 @@ describe('MatCarouselComponent', () => {
       component.next();
       tick();
 
+      expect(component.animationStart.emit).toHaveBeenCalledWith(1);
       expect(component.change.emit).toHaveBeenCalledWith(1);
     }));
 
@@ -112,6 +115,7 @@ describe('MatCarouselComponent', () => {
       component.previous();
       tick();
 
+      expect(component.animationStart.emit).toHaveBeenCalledWith(component.slidesList.length - 1);
       expect(component.change.emit).toHaveBeenCalledWith(component.slidesList.length - 1);
     }));
 
@@ -122,6 +126,7 @@ describe('MatCarouselComponent', () => {
 
       component.autoplay = false;
 
+      expect(component.animationStart.emit).toHaveBeenCalledWith(1);
       expect(component.change.emit).toHaveBeenCalledWith(1);
     }));
   });

--- a/projects/carousel/src/lib/carousel.component.ts
+++ b/projects/carousel/src/lib/carousel.component.ts
@@ -97,6 +97,9 @@ export class MatCarouselComponent
   }
 
   @Output()
+  public animationStart: EventEmitter<number> = new EventEmitter<number>();
+
+  @Output()
   public change: EventEmitter<number> = new EventEmitter<number>();
 
   public get currentIndex(): number {
@@ -360,7 +363,10 @@ export class MatCarouselComponent
     );
     const animation = factory.create(this.carouselList.nativeElement);
 
-    animation.onStart(() => (this.playing = true));
+    animation.onStart(() => {
+      this.playing = true;
+      this.animationStart.emit(this.currentIndex);
+  });
     animation.onDone(() => {
       this.change.emit(this.currentIndex);
       this.playing = false;


### PR DESCRIPTION
Hi Gabriel, I added the animationStart EventEmitter, which emits when animation starts, and it emits the currentIndex just like the change EventEmitter. I updated the unit test, basically I expect animationStart to emit in the same spots where change emits.

regards,

Norman Vásquez